### PR TITLE
Update Python versions and resolve linter issue

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A library for connecting to the [Smartsheet API](https://smartsheet.redoc.ly) fr
 
 ## Requirements
 
-The SDK is compatible with [actively supported](https://devguide.python.org/versions/#versions) Python versions `3.11`, `3.10`, `3.9`, `3.8`, `3.7`.
+The SDK is compatible with [actively supported](https://devguide.python.org/versions/#versions) Python versions `3.11`, `3.10`, `3.9`.
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,6 @@ REQUIRES = [
     'python-dateutil'
 ]
 
-if sys.version_info < (3, 4):
-    REQUIRES.append('enum34')
-
 # test packages:
 # https://github.com/pytest-dev/pytest
 
@@ -53,8 +50,6 @@ setup(
         'Operating System :: OS Independent',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
Update project to drop support for Python 3.7 and 3.8 and resolve linter issue.

* **setup.py**
  - Remove support for Python 3.7 and 3.8 from the `classifiers` list.
  - Remove the `enum34` dependency from the `REQUIRES` list as this checks for python versions below 3.4.

* **README.md**
  - Update the "Requirements" section to mention compatibility with Python 3.9, 3.10, and 3.11.

* **.github/workflows/test-build.yaml**
  - Remove Python 3.7 and 3.8 from the `matrix` list under the `mock-api-test` job.

